### PR TITLE
Uploader组件中Flex增加居中显示，增加计算maxSelectNumber默认值，增加max提示

### DIFF
--- a/library/src/main/ets/components/uploader/index.ets
+++ b/library/src/main/ets/components/uploader/index.ets
@@ -268,12 +268,18 @@ export struct IBestUploader {
 					this.select()
 				})
 			}else{
-				Row(){
+				Column({
+					space: 8
+				}){
 					IBestIcon({
 						name: this.uploaderIcon,
 						iconSize: this.uploaderIconSize,
 						color: this.uploaderIconColor
 					})
+					if (this.max !== undefined) {
+						Text(`(${this.fileList.length}/${this.max})`)
+              .fontColor(IBestUploaderColor.textColor)
+					}
 				}
 				.width(getSizeByUnit(this.previewSize))
 				.aspectRatio(1)

--- a/library/src/main/ets/components/uploader/index.ets
+++ b/library/src/main/ets/components/uploader/index.ets
@@ -143,6 +143,10 @@ export struct IBestUploader {
 	}
 	// 选择文件
 	selectFile(){
+		// 设置maxSelectNumber
+		if (this.max !== undefined) {
+			this.fileSelectOption.maxSelectNumber = this.max - this.fileList.length
+		}
 		const docPicker = new picker.DocumentViewPicker(this.context)
 		docPicker.select(this.fileSelectOption).then(result => {
 			this.onFileSelect(result)
@@ -150,6 +154,10 @@ export struct IBestUploader {
 	}
 	// 选择图片
 	selectImg(){
+		// 设置maxSelectNumber
+		if (this.max !== undefined) {
+			this.imageSelectOption.maxSelectNumber = this.max - this.fileList.length
+		}
 		let photoPicker = new photoAccessHelper.PhotoViewPicker()
 		photoPicker.select(this.imageSelectOption).then((result: photoAccessHelper.PhotoSelectResult) => {
 			this.onFileSelect(result.photoUris)

--- a/library/src/main/ets/components/uploader/index.ets
+++ b/library/src/main/ets/components/uploader/index.ets
@@ -91,6 +91,10 @@ export struct IBestUploader {
      */
 	@Param showPreviewList: boolean = true
 	/**
+	 * 居中对齐显示
+  */
+	@Param center: boolean = false
+	/**
 	 * 自定义上传触发器
 	 */
 	@BuilderParam customUploader: CustomBuilder
@@ -228,7 +232,9 @@ export struct IBestUploader {
 		Flex({ wrap: FlexWrap.Wrap, space: {
 			main: new LengthMetrics(convertDimensions(8), getLengthUnit()),
 			cross: new LengthMetrics(convertDimensions(8), getLengthUnit())
-		}}){
+		},
+      justifyContent: this.center ? FlexAlign.Center : FlexAlign.Start
+    }){
 			if(this.showPreviewList && this.fileList.length){
 				ForEach(this.fileList, (item: IBestUploaderFile, index: number) => {
 					UploadItem({
@@ -282,6 +288,7 @@ export struct IBestUploader {
 				})
 			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
Uploader组件中Flex增加居中显示，保证不影响旧组件使用，默认为false

<img width="344" height="730" alt="image" src="https://github.com/user-attachments/assets/e7eb38a9-c6fa-417f-8280-2139e83035e6" />

<img width="326" height="704" alt="image" src="https://github.com/user-attachments/assets/96a381b8-1e17-469c-a95a-7a7a5f9de6a8" />

增加计算maxSelectNumber默认值，自动根据fileList计算，使用户不可选择超过max数量
<img width="107" height="53" alt="image" src="https://github.com/user-attachments/assets/9ed4ede4-1f93-4881-9154-1f954f8966cd" />
