### PR TITLE
fix(IBestCalendarDialog): 修复多选模式单选确认后值类型退化为字符串的bug

### DIFF
--- a/library/src/main/ets/components/calendar/calendarDialog.ets
+++ b/library/src/main/ets/components/calendar/calendarDialog.ets
@@ -176,7 +176,7 @@ export struct IBestCalendarDialog {
 	// 获取日历选择结果 触发onConfirm回调函数 并关闭弹框
 	onGetCalendarResult(value: IBestCalendarConfirmResult[]) {
 		if (value.length) {
-			this.$value(value.length == 1 ? value[0].dateStr : value.map(item => item.dateStr))
+			this.$value(Array.isArray(value)&&value.length===1?value.map(item=>item.dateStr):value[0].dateStr)
 			this.onConfirm(value)
 			this.$visible(false)
 		}


### PR DESCRIPTION
当父组件传入字符串类型数组（双向绑定）且 selectType=multiple 时，
仅选中一项点击确定，原逻辑直接取 value[0].dateStr 返回单字符串，
导致 $value 类型由数组降级为字符串，与父组件预期类型不一致。

bug复现代码：
```
import {
  IBestCalendarDialog, IBestField, IBestForm, IBestFormController } from '@ibestservices/ibest-ui-v2'
import { modeColor } from '../../assets/styles/BaseStyle'
import CustomNavBar from '../../components/CustomNavBar'

@Builder
export function CalendarBuilder(_: string, title: string) {
  CalendarPage({ title })
}

@Entry
@ComponentV2
struct CalendarPage {
  @Param title: string = ''
  @Local bugMultipleVisible: boolean = false
  @Local bugMultipleDateRange: string[] = []
  private fromId="123"
  @Local controller:IBestFormController=new IBestFormController()
  @Computed
  get bugMultipleDateRangeText() {
    console.dir(this.bugMultipleDateRange)
    if (!Array.isArray(this.bugMultipleDateRange)) {
      return "源类型已经改变bug触发"
    }
    return "源类型未改变bug未触发"
  }



  build() {
    NavDestination() {
      CustomNavBar({ title: this.title })
      IBestForm({
        formId:this.fromId,
        controller:this.controller
      })
      {
        IBestField({
          formId:this.fromId,
          isLink:true,
          value:this.bugMultipleDateRangeText,
          label:"bug测试",
          onFieldClick:()=>{
            this.bugMultipleVisible=true
          }
        })
      }
      IBestCalendarDialog({
        visible: this.bugMultipleVisible!!,
        value: this.bugMultipleDateRange!!,
        selectType:"multiple",
      })
    }
    .hideTitleBar(true)
    .backgroundColor(modeColor.bg)
  }
}
```
修改 at calendarDialog.ets:179：
- 增加 Array.isArray(value) 守卫，防御非数组输入
- 单元素数组改为 value.map(item => item.dateStr)，确保仍返回数组
- 非数组分支保留 value[0].dateStr 作为兜底